### PR TITLE
Add Chinese and Spanish translations for marketplace docs

### DIFF
--- a/content/asciidoc-pages/docs/marketplace-guide/index.es.adoc
+++ b/content/asciidoc-pages/docs/marketplace-guide/index.es.adoc
@@ -1,0 +1,111 @@
+= Guía para Publicadores del Marketplace de Adoptium(R)
+:description: Guía para publicadores del Marketplace de Adoptium: pasos para publicar binarios OpenJDK, requisitos TCK, verificación AQAvit y metadatos del producto
+:keywords: guía publicadores marketplace Adoptium, publicador OpenJDK, marketplace Java, verificación AQAvit, TCK Oracle, Eclipse Adoptium
+:orgname: Eclipse Adoptium
+:lang: es
+:page-authors: gdams, tellison, jiekang
+:page-based-on: 848c4fbb777b4c656ba5f667fd037a6df72559fd
+
+== Introducción
+
+Este documento proporciona orientación para los publicadores que son elegibles para comercializar y promover entornos de ejecución OpenJDK a través del
+link:/marketplace[Marketplace de Adoptium].
+
+Los publicadores pueden ser vendedores, entidades sin fines de lucro, grupos de usuarios y otros que compartan los valores plasmados en la
+link:/docs/marketplace-policy[política del marketplace de Adoptium^].
+Los publicadores pueden ofrecer productos de código abierto o con licencia comercial, utilizables de forma gratuita o de pago para el usuario final. El marketplace no requiere versión, plataforma, términos de uso o de licencia específicos, y los binarios disponibles a través del marketplace también pueden estar disponibles en otros lugares. Todos los binarios ofrecidos a través del marketplace de Adoptium deben cumplir con los criterios de compatibilidad y calidad definidos en la política del marketplace.
+
+El marketplace está disponible para los usuarios finales como
+link:/marketplace[sitio web]
+y como
+https://marketplace-api.adoptium.net/[interfaz de programación de aplicaciones^]
+(API) alojada y mantenida por el proyecto Adoptium.
+
+Se anima a los publicadores a que discutan su participación en el marketplace con el
+link:/members[Grupo de Trabajo Adoptium],
+quien les proporcionará orientación y asistencia con los pasos descritos a continuación. En caso de contradicciones entre las políticas formales y los acuerdos referenciados a continuación y esta guía para publicadores, prevalecerán las políticas formales y los acuerdos.
+
+
+== Pasos Preparatorios No Técnicos
+
+Los posibles publicadores y sus productos deben cumplir con los criterios descritos en la
+link:/marketplace-policy[Política del Marketplace de Adoptium]. Estos criterios incluyen convertirse en miembro del grupo de trabajo Adoptium en un nivel apropiado, lo que le otorga voz en la política y el funcionamiento del marketplace. No todos los miembros del grupo de trabajo serán publicadores. También se anima a los usuarios finales a unirse al grupo de trabajo para ayudar a orientar los productos y requisitos de los productos del marketplace.
+
+Los miembros del grupo de trabajo que deseen publicar un producto en el marketplace deben aceptar el
+https://www.eclipse.org/legal/documents/eclipse-adoptium-marketplace-publisher-agreement.pdf[Acuerdo de Publicador del Marketplace de Adoptium]. Este acuerdo establece los términos y condiciones bajo los cuales la Fundación Eclipse acepta la promoción de su producto. Los productos se beneficiarán de iniciativas de marketing destinadas a promover el valor de los binarios en este contexto cuando sean aceptados en el marketplace.
+
+
+== Descripción General del Proceso de Publicación
+
+El sitio web y la API del marketplace de Adoptium se basan en los metadatos que usted proporciona sobre sus productos elegibles. Los metadatos se ponen a disposición en formato legible por máquina
+https://www.json.org/[JSON^]
+junto con una
+https://en.wikipedia.org/wiki/Digital_signature[firma digital segura^]
+para garantizar la autenticidad, integridad y no repudio de la información que usted publica.
+
+Como publicador, usted es responsable de auto-certificar que la información de cada producto descrito en los metadatos es precisa y se ajusta a sus obligaciones en la
+link:/marketplace-policy[Política del Marketplace].
+
+Usted controla los metadatos de sus productos y la frecuencia con que se actualizan. La aplicación del marketplace de Adoptium utilizará esa información para comercializar sus productos y dirigir a los usuarios a descargar su producto directamente desde un sitio bajo su control. Adoptium no aloja ni distribuye sus binarios.
+
+Cuando se inicia una descarga a través del marketplace de Adoptium, los usuarios serán dirigidos a una página post-descarga donde puede proporcionar un enlace a información adicional sobre su producto, organización, servicios, etc.
+
+
+== Proporcionando Información del Publicador
+
+Los publicadores deben proporcionar la siguiente información para ser incluidos en el marketplace.
+
+ * Nombre del publicador: cómo desea ser conocido en el sitio web y la API del marketplace.
+ * Imagen del logotipo: una representación visual de usted como publicador para su uso en el sitio web.
+ * Ubicación de datos del listado: la URL base que Adoptium utilizará para recuperar los metadatos del listado del marketplace.
+ * Clave pública de firma: la clave pública que usaremos para verificar su firma.
+ * Página post-descarga: la página web a la que debemos dirigir a los usuarios del sitio web al descargar su producto.
+
+No esperamos que cambie estos datos con frecuencia, ya que Adoptium los incorporará en la configuración de la aplicación del marketplace.
+
+La información del publicador se proporciona abriendo una
+https://github.com/adoptium/adoptium/issues/new/choose[nueva solicitud de publicador^]
+en el repositorio de Adoptium. Puede abrir una nueva solicitud en el mismo repositorio si necesita cambiarla posteriormente.
+
+
+== Superando las Pruebas TCK de Oracle
+
+Cada binario que publique a través del marketplace de Adoptium debe satisfacer completamente todos los requisitos del TCK vigente para la versión de la Plataforma Java que está promoviendo a través del marketplace de Adoptium. Usted es responsable de asegurarse de que esto haya ocurrido antes de publicar el binario. Adoptium no realizará esta verificación en su nombre.
+
+Los proyectos de Adoptium
+https://projects.eclipse.org/projects/adoptium.temurin-compliance[desarrollan y utilizan herramientas^]
+que facilitan la ejecución y el análisis del TCK. Los publicadores son bienvenidos a participar en el proyecto técnico y utilizar estas herramientas para ayudar con la tarea de ejecutar el TCK en sus propios productos.
+
+
+== Superando las Pruebas de Verificación AQAvit
+
+Cada binario que publique a través del marketplace de Adoptium debe satisfacer completamente todos los requisitos del conjunto de pruebas AQAvit vigente para la versión que está promoviendo a través del marketplace de Adoptium. Usted es responsable de asegurarse de que esto haya ocurrido antes de publicar el binario. Adoptium no realizará esta verificación en su nombre.
+
+El
+link:/aqavit[proceso de verificación AQAvit]
+debe satisfacerse en el momento en que el binario se ofrece inicialmente a través del marketplace. Los publicadores no están obligados a verificar el binario con versiones posteriores del conjunto de verificación AQAvit. Una vez que un binario cumple con los criterios, puede seguir ofreciéndose a través del marketplace.
+
+AQAvit es un conjunto de pruebas de código abierto gestionado en el proyecto Adoptium. Los publicadores son bienvenidos a participar en el proyecto AQAvit para obtener ayuda con la tarea de ejecutar AQAvit en sus propios productos.
+
+
+== Información del Listado de Productos
+
+El listado de sus productos para el marketplace puede estar alojado en cualquier lugar bajo su control directo que admita solicitudes y respuestas
+https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol[HTTP^],
+incluida su propia propiedad web, GitHub, etc. Aunque Adoptium verificará que la información se recibe de usted de forma segura mediante una firma digital basada en información verificada, usted es en última instancia responsable de la información proporcionada al marketplace a través de la URL de ubicación de datos del listado.
+
+La información del listado de productos comprende archivos en formato JSON estructurado, con flexibilidad para permitir múltiples compilaciones y versiones. La información tiene como raíz la ubicación de datos del listado proporcionada en la <<Proporcionando-Información-del-Publicador,información del publicador>> en el formato descrito en la documentación del
+link:/docs/marketplace-listing[Repositorio de Listado de Productos del Publicador del Marketplace de Adoptium].
+
+// TODO: How does a publisher check the logs of successful/failed pulls and schema validation?
+La información del listado de productos será rechazada si no cumple con la
+link:/docs/marketplace-listing[estructura del listado de productos],
+el esquema del archivo del marketplace, o si la firma no verifica el contenido correctamente. Nos pondremos en contacto con usted si el archivo de listado falla repetidamente estas validaciones.
+
+== Página Post-descarga
+
+// TODO: Should the post-download be per-publisher or per-product (i.e. embedded in the metadata).
+Cuando un usuario elige descargar su producto a través del sitio web del marketplace, será dirigido a una página post-descarga mientras la descarga se inicia desde su servidor de distribución. La página post-descarga agradecerá al usuario e identificará al publicador, incluyendo un enlace a una página web de su elección. Imaginamos que esta página web llevará al usuario a información sobre su producto, organización, servicios, etc.
+
+El enlace a la página post-descarga no es utilizado por la
+https://marketplace-api.adoptium.net/[API del marketplace de Adoptium].

--- a/content/asciidoc-pages/docs/marketplace-guide/index.es.adoc
+++ b/content/asciidoc-pages/docs/marketplace-guide/index.es.adoc
@@ -1,6 +1,6 @@
 = Guía para Publicadores del Marketplace de Adoptium(R)
-:description: Guía para publicadores del Marketplace de Adoptium: pasos para publicar binarios OpenJDK, requisitos TCK, verificación AQAvit y metadatos del producto
-:keywords: guía publicadores marketplace Adoptium, publicador OpenJDK, marketplace Java, verificación AQAvit, TCK Oracle, Eclipse Adoptium
+:description: Guía para Publicadores del Marketplace de Adoptium
+:keywords: marketplace adoptium
 :orgname: Eclipse Adoptium
 :lang: es
 :page-authors: gdams, tellison, jiekang

--- a/content/asciidoc-pages/docs/marketplace-guide/index.zh-CN.adoc
+++ b/content/asciidoc-pages/docs/marketplace-guide/index.zh-CN.adoc
@@ -1,0 +1,116 @@
+= Adoptium(R) 市场发布商指南
+:description: Adoptium 市场发布商指南：发布 OpenJDK 二进制文件的步骤，包括 TCK 合规、AQAvit 验证和产品元数据要求
+:keywords: Adoptium 市场发布商指南, OpenJDK 市场, Java 发布商, AQAvit 验证, TCK 认证, Eclipse Adoptium
+:orgname: Eclipse Adoptium
+:lang: zh-CN
+:page-authors: gdams, tellison, jiekang
+:page-based-on: 848c4fbb777b4c656ba5f667fd037a6df72559fd
+
+== 简介
+
+本文档为有资格通过
+link:/marketplace[Adoptium 市场]
+推广和销售 OpenJDK 运行时的发布商提供指导。
+
+发布商可以是供应商、非营利实体、用户组以及其他认同
+link:/docs/marketplace-policy[Adoptium 市场政策^]
+中所体现价值观的组织。发布商可提供开源或商业授权的产品，对最终用户可以免费或收费。市场不要求特定的版本、平台、使用或许可条款，通过市场提供的二进制文件也可能在其他地方获得。所有通过 Adoptium 市场提供的二进制文件必须符合市场政策中定义的兼容性和质量标准。
+
+市场以
+link:/marketplace[网站]
+和
+https://marketplace-api.adoptium.net/[应用程序编程接口^]
+(API) 两种形式提供给最终用户，由 Adoptium 项目托管和维护。
+
+鼓励发布商与
+link:/members[Adoptium 工作组]
+讨论其在市场中的参与事宜，工作组将对以下步骤提供指导和协助。如果以下正式政策和协议与本发布商指南存在任何矛盾，以正式政策和协议为准。
+
+
+== 准备工作（非技术性）
+
+潜在发布商及其产品必须满足
+link:/marketplace-policy[Adoptium 市场政策]
+中描述的标准。这些标准包括以适当级别加入 Adoptium 工作组，使您在市场的政策和运营中拥有发言权。并非工作组的每位成员都会成为发布商。也鼓励最终用户加入工作组，以帮助指导市场产品的方向和需求。
+
+希望在市场中发布产品的工作组成员必须同意
+https://www.eclipse.org/legal/documents/eclipse-adoptium-marketplace-publisher-agreement.pdf[Adoptium 市场发布商协议]。
+该协议规定了 Eclipse 基金会接受您的产品推广的条款和条件。被市场接受后，产品将从旨在推广该上下文中二进制文件价值的营销活动中受益。
+
+
+== 发布流程概述
+
+Adoptium 市场网站和 API 由您提供的关于您的合格产品的元数据驱动。您以
+https://www.json.org/[JSON^]
+机器可读格式提供元数据，并附带
+https://en.wikipedia.org/wiki/Digital_signature[安全数字签名^]，
+以确保您发布信息的真实性、完整性和不可否认性。
+
+作为发布商，您负责自我认证元数据中描述的每个产品的信息是准确的，并符合您在
+link:/marketplace-policy[市场政策]
+中的义务。
+
+您控制产品元数据及其更新频率。Adoptium 市场应用程序将利用这些信息推广您的产品，并引导用户直接从您控制的网站下载您的产品。Adoptium 不托管或分发您的二进制文件。
+
+当通过 Adoptium 市场发起下载时，用户将被引导至下载后页面，您可以在那里提供关于您的产品、组织、服务等额外信息的链接。
+
+
+== 提供发布商信息
+
+发布商必须提供以下信息才能被纳入市场。
+
+ * 发布商名称：您希望在市场网站和 API 中的显示方式。
+ * 徽标图像：在网站上作为您发布商身份的视觉展示。
+ * 上架数据位置：Adoptium 用于检索您的市场上架元数据的基础 URL。
+ * 签名公钥：我们将用于验证您签名的公钥。
+ * 下载后页面：下载您的产品时，我们应将网站用户引导至的网页。
+
+我们不期望您频繁更改这些信息，因为 Adoptium 会将这些内容添加到市场应用程序配置中。
+
+发布商信息通过在 Adoptium 仓库中提交
+https://github.com/adoptium/adoptium/issues/new/choose[新的发布商申请议题^]
+来提供。如果您后续需要更改，也可以在同一仓库中提出新议题。
+
+
+== 通过 Oracle TCK 测试
+
+您通过 Adoptium 市场发布的每个二进制文件必须完全满足您通过 Adoptium 市场推广的 Java 平台版本的当前 TCK 的所有要求。您负责在发布二进制文件之前确保已完成此验证。Adoptium 不会代表您进行检查。
+
+Adoptium 项目
+https://projects.eclipse.org/projects/adoptium.temurin-compliance[开发和使用工具^]
+使运行和分析 TCK 变得更加容易。欢迎发布商参与技术项目并使用这些工具来帮助在其自己的产品上运行 TCK。
+
+
+== 通过 AQAvit 验证测试
+
+您通过 Adoptium 市场发布的每个二进制文件必须完全满足您通过 Adoptium 市场推广的版本的当前 AQAvit 测试套件的所有要求。您负责在发布二进制文件之前确保已完成此验证。Adoptium 不会代表您进行检查。
+
+link:/aqavit[AQAvit 验证流程]
+必须在二进制文件首次通过市场提供时得到满足。发布商不需要针对 AQAvit 验证套件的后续版本验证二进制文件。一旦二进制文件满足标准，就可以继续通过市场提供。
+
+AQAvit 是由 Adoptium 项目管理的开源测试套件。欢迎发布商参与 AQAvit 项目，以获取在其自己产品上运行 AQAvit 的帮助。
+
+
+== 产品上架信息
+
+您在市场上的产品上架信息可以托管在任何您直接控制的、支持
+https://en.wikipedia.org/wiki/Hypertext_Transfer_Protocol[HTTP^]
+请求和响应的地方，包括您自己的网站、GitHub 等。虽然 Adoptium 会通过使用基于已验证信息的数字签名来确认安全地从您那里接收信息，但您最终对通过上架数据位置 URL 提供给市场的信息负责。
+
+产品上架信息由结构化 JSON 格式文件组成，可灵活支持多个构建版本。信息以<<提供发布商信息,发布商信息>>中提供的上架数据位置为根目录，格式描述见
+link:/docs/marketplace-listing[Adoptium 市场发布商产品上架仓库]
+文档。
+
+// TODO: How does a publisher check the logs of successful/failed pulls and schema validation?
+如果产品上架信息不符合
+link:/docs/marketplace-listing[产品上架结构]、
+市场文件模式，或签名无法成功验证内容，则该信息将被拒绝。如果上架文件多次未通过这些验证检查，我们将与您联系。
+
+== 下载后页面
+
+// TODO: Should the post-download be per-publisher or per-product (i.e. embedded in the metadata).
+当用户通过市场网站选择下载您的产品时，他们将被引导至下载后页面，同时从您的分发服务器发起下载。下载后页面将感谢用户并标识发布商，包括指向您所选网页的链接。我们预想该网页将引导用户了解您的产品、组织、服务等相关信息。
+
+下载后页面链接不被
+https://marketplace-api.adoptium.net/[Adoptium 市场 API]
+使用。

--- a/content/asciidoc-pages/docs/marketplace-guide/index.zh-CN.adoc
+++ b/content/asciidoc-pages/docs/marketplace-guide/index.zh-CN.adoc
@@ -1,6 +1,6 @@
 = Adoptium(R) 市场发布商指南
-:description: Adoptium 市场发布商指南：发布 OpenJDK 二进制文件的步骤，包括 TCK 合规、AQAvit 验证和产品元数据要求
-:keywords: Adoptium 市场发布商指南, OpenJDK 市场, Java 发布商, AQAvit 验证, TCK 认证, Eclipse Adoptium
+:description: Adoptium 市场发布商指南
+:keywords: adoptium 市场
 :orgname: Eclipse Adoptium
 :lang: zh-CN
 :page-authors: gdams, tellison, jiekang

--- a/content/asciidoc-pages/docs/marketplace-policy/index.es.adoc
+++ b/content/asciidoc-pages/docs/marketplace-policy/index.es.adoc
@@ -1,0 +1,74 @@
+= Política del Marketplace de Productos de Software de Adoptium(R)
+:description: Política del Marketplace de Adoptium: criterios de calidad, verificación AQAvit y compatibilidad Java SE para binarios OpenJDK
+:keywords: política marketplace Adoptium, marketplace OpenJDK, verificación AQAvit, compatibilidad Java SE, calidad Java, Eclipse Adoptium
+:orgname: Eclipse Adoptium
+:lang: es
+:page-authors: gdams, tellison
+:page-based-on: 848c4fbb777b4c656ba5f667fd037a6df72559fd
+
+== Descripción General
+
+El Marketplace de Adoptium proporciona a los usuarios acceso sencillo a una amplia variedad de binarios OpenJDK Java de alta calidad y totalmente compatibles, y ofrece a las organizaciones que producen dichos binarios un mecanismo para ampliar la distribución de sus entornos de ejecución Java.
+
+=== Beneficios para los Usuarios
+
+Todos los binarios disponibles a través del marketplace de Adoptium
+link:/marketplace[sitio web]
+y la
+https://marketplace-api.adoptium.net/q/swagger-ui/[API^]
+son compatibles con Java SE y han demostrado estar listos para su uso en producción en una amplia variedad de entornos al superar el conjunto de verificación de calidad
+link:/aqavit[AQAvit^].
+
+El
+https://projects.eclipse.org/projects/adoptium.aqavit[conjunto de verificación AQAvit^]
+evalúa los entornos de ejecución Java en cuanto a corrección funcional, rendimiento, resiliencia, seguridad y la capacidad de superar una gran variedad de conjuntos de pruebas de aplicaciones. Como resultado, las empresas obtienen un mayor grado de confianza en los binarios que incorporan a sus organizaciones y a sus cadenas de suministro de software.
+
+=== Beneficios para los Productores
+
+Los siguientes beneficios son disfrutados por todos los productores listados en el marketplace de Adoptium.
+
+ * Demuestra que su producto es una oferta de alta calidad, lista para uso empresarial, al haber superado los criterios de inclusión de compatibilidad Java y calidad AQAvit requeridos.
+ * Muestra que su producto cumple con todos los requisitos del Grupo de Trabajo Eclipse Adoptium en cuanto a seguridad, escalabilidad, durabilidad y corrección funcional en una versión y compilación específicas.
+ * Declara que el proveedor es un participante de la comunidad Adoptium y apoya la definición y el alcance de los criterios de calidad AQAvit en toda la industria.
+ * Los productos listados se benefician de iniciativas de marketing y promoción patrocinadas por el Grupo de Trabajo Adoptium en toda la industria, con el apoyo de la Fundación Eclipse.
+
+La inclusión en el marketplace está abierta a todos los miembros estratégicos y empresariales del grupo de trabajo Adoptium sin costo adicional para el proveedor, es no exclusiva y preserva la oportunidad de ofrecer servicios de pago junto con la oferta.
+
+== Verificación de Productos de Software AQAvit
+
+Solo aquellos productos que superen el conjunto de pruebas de verificación de productos de software AQAvit y cumplan con las obligaciones de la
+https://www.eclipse.org/legal/eclipse-foundation-quality-verification-suite-license.php[Licencia del Conjunto de Verificación de Calidad de la Fundación Eclipse^]
+podrán incluirse en el Marketplace de Adoptium.
+
+Es necesario
+link:/aqavit[verificar cada binario]
+que desee incluirse en el Marketplace de Adoptium. No es necesario ser miembro del grupo de trabajo Adoptium para producir un producto de software verificado por AQAvit.
+
+== Compatibilidad con Java SE
+
+El cumplimiento de la especificación Java SE se determina exclusivamente mediante el uso del
+https://en.wikipedia.org/wiki/Technology_Compatibility_Kit[Kit de Compatibilidad de Tecnología^]
+(TCK) de Oracle para la Plataforma Java, también denominado Kit de Compatibilidad Java (JCK).
+
+El kit de pruebas JCK es propiedad de Oracle y no está disponible bajo una licencia de código abierto. Eclipse no prueba productos de software de terceros para la compatibilidad con Java. Los productores deben contactar con Oracle para obtener su propia licencia de uso del JCK para dichos fines.
+
+== Listado en el Marketplace de Adoptium
+
+El Marketplace de Adoptium es una oportunidad para que los Miembros del Grupo de Trabajo Adoptium ("Productores") exhiban productos de software y proyectos de código abierto ("Productos") que hayan demostrado ser de alta calidad y estar listos para uso empresarial.
+
+Los productos listados en el marketplace *DEBEN* cumplir con los siguientes criterios.
+
+. El Producto debe superar el conjunto de verificación de calidad Eclipse AQAvit (QVS) correspondiente y cumplir con la
+https://www.eclipse.org/legal/eclipse-foundation-quality-verification-suite-license.php[Licencia del Conjunto de Verificación de Calidad de la Fundación Eclipse^].
+. El Productor debe declarar, a satisfacción del Grupo de Trabajo Adoptium, que el Producto ha superado el Kit de Compatibilidad de Tecnología Java SE aplicable.
+. El Productor debe ser Participante, Miembro Empresarial o Miembro Estratégico del Grupo de Trabajo Adoptium.
+. El Productor debe firmar el
+https://www.eclipse.org/legal/documents/eclipse-adoptium-marketplace-publisher-agreement.pdf[Acuerdo de Editor del Marketplace Eclipse Adoptium^]
+y cumplir con todas sus obligaciones.
+
+Los productos que cumplan estos requisitos son elegibles para ser listados en el marketplace. Para ser listados, el Productor debe
+https://github.com/adoptium/adoptium/issues/new[abrir una solicitud con el Grupo de Trabajo Adoptium^]
+solicitando su inclusión como Productor en el marketplace.
+
+Los cambios en esta política son realizados por el
+link:/members[Comité Directivo del Grupo de Trabajo Adoptium].

--- a/content/asciidoc-pages/docs/marketplace-policy/index.es.adoc
+++ b/content/asciidoc-pages/docs/marketplace-policy/index.es.adoc
@@ -1,6 +1,6 @@
 = Política del Marketplace de Productos de Software de Adoptium(R)
-:description: Política del Marketplace de Adoptium: criterios de calidad, verificación AQAvit y compatibilidad Java SE para binarios OpenJDK
-:keywords: política marketplace Adoptium, marketplace OpenJDK, verificación AQAvit, compatibilidad Java SE, calidad Java, Eclipse Adoptium
+:description: Política del Marketplace de Adoptium
+:keywords: política de marketplace Adoptium
 :orgname: Eclipse Adoptium
 :lang: es
 :page-authors: gdams, tellison

--- a/content/asciidoc-pages/docs/marketplace-policy/index.zh-CN.adoc
+++ b/content/asciidoc-pages/docs/marketplace-policy/index.zh-CN.adoc
@@ -1,0 +1,75 @@
+= Adoptium(R) 软件产品市场政策
+:description: Adoptium 市场政策：OpenJDK Java 二进制文件的质量标准、AQAvit 验证和 Java SE 兼容性要求
+:keywords: Adoptium 市场政策, OpenJDK 市场, AQAvit 验证, Java SE 兼容性, Java 质量认证, Eclipse Adoptium
+:orgname: Eclipse Adoptium
+:lang: zh-CN
+:page-authors: gdams, tellison
+:page-based-on: 848c4fbb777b4c656ba5f667fd037a6df72559fd
+
+== 概述
+
+Adoptium 市场为用户提供便捷访问各种高质量、完全兼容的 OpenJDK Java 二进制文件的途径，同时为生产这些二进制文件的组织提供扩大其 Java 运行时分发范围的机制。
+
+=== 用户权益
+
+通过 Adoptium 市场
+link:/marketplace[网站]
+和
+https://marketplace-api.adoptium.net/q/swagger-ui/[API^]
+获取的所有二进制文件均符合 Java SE 标准，并通过
+link:/aqavit[AQAvit^]
+质量验证套件，证明其可在各种生产环境中稳定运行。
+
+https://projects.eclipse.org/projects/adoptium.aqavit[AQAvit 验证套件^]
+从功能正确性、性能、韧性、安全性以及通过各类应用程序测试套件的能力等维度评估 Java 运行时。因此，企业在将这些二进制文件引入公司及纳入软件供应链时，可获得更高程度的信心保障。
+
+=== 生产商权益
+
+以下权益由所有在 Adoptium 市场中列出的生产商共同享有。
+
+ * 证明其产品是高质量的产品，通过了所需的 Java 兼容性和 AQAvit 质量入围标准，可供企业使用。
+ * 表明其产品在特定版本和构建中满足 Eclipse Adoptium 工作组对安全性、可扩展性、耐用性和功能正确性的所有要求。
+ * 声明提供商是 Adoptium 社区的参与者，并在整个行业中支持 AQAvit 质量标准的定义和范围。
+ * 上市产品将受益于 Adoptium 工作组在 Eclipse 基金会支持下发起的全行业营销和推广活动。
+
+市场准入对 Adoptium 工作组所有战略成员和企业成员开放，提供商无需支付额外费用，且为非独家性质，并保留在产品旁提供付费服务的机会。
+
+== AQAvit 软件产品验证
+
+只有通过 AQAvit 软件产品验证测试套件并符合
+https://www.eclipse.org/legal/eclipse-foundation-quality-verification-suite-license.php[Eclipse 基金会质量验证套件许可证^]
+义务的产品，才可被纳入 Adoptium 市场。
+
+每个希望纳入 Adoptium 市场的二进制文件都必须
+link:/aqavit[经过验证]。
+生产经过 AQAvit 验证的软件产品无需成为 Adoptium 工作组成员。
+
+== Java SE 兼容性
+
+Java SE 规范的合规性完全通过使用 Oracle 的
+https://en.wikipedia.org/wiki/Technology_Compatibility_Kit[技术兼容性套件 (TCK)^]
+来确定，该套件用于 Java 平台，也称为 Java 兼容性套件 (JCK)。
+
+JCK 测试套件是 Oracle 的财产，不在开源许可证下提供。Eclipse 不对第三方软件产品进行 Java 兼容性测试。生产商应联系 Oracle，以获取将 JCK 用于此类目的的许可证。
+
+== 在 Adoptium 市场中上架
+
+Adoptium 市场是 Adoptium 工作组成员（"生产商"）展示已证明高质量且适合企业使用的软件产品和开源项目（"产品"）的平台。
+
+市场中上架的产品 *必须* 符合以下标准。
+
+. 产品必须通过相关的 Eclipse AQAvit 质量验证套件 (QVS) 并符合
+https://www.eclipse.org/legal/eclipse-foundation-quality-verification-suite-license.php[Eclipse 基金会质量验证套件许可证^]。
+. 生产商必须向 Adoptium 工作组声明，该产品已通过适用的 Java SE 技术兼容性套件。
+. 生产商必须是 Adoptium 工作组的参与者、企业成员或战略成员。
+. 生产商必须签署
+https://www.eclipse.org/legal/documents/eclipse-adoptium-marketplace-publisher-agreement.pdf[Eclipse Adoptium 市场发布商协议^]
+并履行其中的所有义务。
+
+满足上述要求的产品有资格在市场中上架。如需上架，生产商应
+https://github.com/adoptium/adoptium/issues/new[向 Adoptium 工作组提交申请^]，
+寻求以生产商身份纳入市场。
+
+本政策的变更由
+link:/members[Adoptium 工作组指导委员会]
+负责执行。

--- a/content/asciidoc-pages/docs/marketplace-policy/index.zh-CN.adoc
+++ b/content/asciidoc-pages/docs/marketplace-policy/index.zh-CN.adoc
@@ -1,6 +1,6 @@
 = Adoptium(R) 软件产品市场政策
-:description: Adoptium 市场政策：OpenJDK Java 二进制文件的质量标准、AQAvit 验证和 Java SE 兼容性要求
-:keywords: Adoptium 市场政策, OpenJDK 市场, AQAvit 验证, Java SE 兼容性, Java 质量认证, Eclipse Adoptium
+:description: Adoptium 市场政策
+:keywords: Adoptium 市场政策
 :orgname: Eclipse Adoptium
 :lang: zh-CN
 :page-authors: gdams, tellison


### PR DESCRIPTION
# Description of change

This PR adds Chinese (zh-CN) and Spanish (es) translations for the Adoptium marketplace documentation, including:

- **Marketplace Publisher Guide** (`marketplace-guide/index.zh-CN.adoc` and `index.es.adoc`): Complete translations of the publisher guide covering preparation steps, publishing process, publisher information requirements, TCK/AQAvit testing, product listing information, and post-download pages.

- **Marketplace Policy** (`marketplace-policy/index.zh-CN.adoc` and `index.es.adoc`): Complete translations of the marketplace policy covering user benefits, producer benefits, AQAvit verification, Java SE compatibility, and listing requirements.

All translations are based on the same source commit (848c4fbb777b4c656ba5f667fd037a6df72559fd) and maintain the same structure and content as the English versions with appropriate language-specific formatting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Marketplace publisher guide now available in Spanish and Chinese, covering publisher requirements, technical preparation, submission workflows, compliance testing, and product listing specifications
* Marketplace policy documentation now available in Spanish and Chinese, including marketplace standards, AQAvit verification requirements, Java SE compatibility guidelines, and publisher agreement procedures

<!-- end of auto-generated comment: release notes by coderabbit.ai -->